### PR TITLE
Mark alpine-rootfs as EOL

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,34 @@
+From bcb1aa14a4a93435694ad7c50632d7321d84527c Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Fri, 9 Aug 2024 02:35:53 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+---
+ appstream.xml | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/appstream.xml b/appstream.xml
+index cc20607..dd7534d 100644
+--- a/appstream.xml
++++ b/appstream.xml
+@@ -18,13 +18,14 @@
+   <screenshots>
+     <screenshot type="default">
+       <caption>General usage</caption>
+-      <image>https://paledega.github.io/alpine-rootfs/image.png</image>
++      <image>https://i.imgur.com/XypFNg3.png</image>
+     </screenshot>
+   </screenshots>
+ 
+-  <url type="homepage">https://paledega.github.io/alpine-rootfs</url>
++  <!--<url type="homepage">https://paledega.github.io/alpine-rootfs</url>-->
++  <url type="homepage">https://github.com/flathub/io.github.paledega.alpine-rootfs</url>
+   <project_group>ALPINE</project_group>
+-  <content_rating type="oars-1.0" />
++  <content_rating type="oars-1.1" />
+   <developer_name>paledega</developer_name>
+   <releases>
+     <release version="20220916" date="2022-09-16">
+--
+libgit2 1.7.2
+

--- a/io.github.paledega.alpine-rootfs.yaml
+++ b/io.github.paledega.alpine-rootfs.yaml
@@ -23,6 +23,8 @@ modules:
       - type: archive
         url: https://github.com/flathub/io.github.paledega.alpine-rootfs/releases/download/20221006/20221006.zip
         sha256: 947d81ab1fb27d81564c5cb63f6d54b7df9b60dcf417d97b1328e32398c9538e
+      - type: patch
+        path: fix-appdata.patch
       - type: file
         url: https://github.com/flathub/io.github.paledega.alpine-rootfs/releases/download/20221006/alpine.tar.gz
         sha256: af9b72a3446e713f3169434e8376e59965eaba5d9334b6bd441a9c44f1b292d4

--- a/io.github.paledega.alpine-rootfs.yaml
+++ b/io.github.paledega.alpine-rootfs.yaml
@@ -21,9 +21,9 @@ modules:
       - install -D src/icon.svg /app/share/icons/hicolor/scalable/apps/io.github.paledega.alpine-rootfs.svg
     sources:
       - type: archive
-        url: https://github.com/paledega/alpine-rootfs/archive/refs/tags/20221006.zip
+        url: https://github.com/flathub/io.github.paledega.alpine-rootfs/releases/download/20221006/20221006.zip
         sha256: 947d81ab1fb27d81564c5cb63f6d54b7df9b60dcf417d97b1328e32398c9538e
       - type: file
-        url: https://github.com/paledega/alpine-rootfs/releases/download/20221006/alpine.tar.gz
+        url: https://github.com/flathub/io.github.paledega.alpine-rootfs/releases/download/20221006/alpine.tar.gz
         sha256: af9b72a3446e713f3169434e8376e59965eaba5d9334b6bd441a9c44f1b292d4
       


### PR DESCRIPTION
> This application is no longer maintained.

Source: https://github.com/paledega/alpine-rootfs

Fixes: https://github.com/flathub/io.github.paledega.alpine-rootfs/issues/2